### PR TITLE
Fix OpenBSD XPREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 PROJECT = sdwmbar
 CC ?= cc
 
-PREFIX ?= /usr/local
-XPREFIX ?= /usr/local
-
 OS != uname
 .if ${OS} == OpenBSD
 XPREFIX ?= /usr/X11R6
 .endif
+PREFIX ?= /usr/local
+XPREFIX ?= /usr/local
 
 INCS   = -I${XPREFIX}/include
 LINKS  = -L${XPREFIX}/lib -lX11


### PR DESCRIPTION
Please accept this quick fix for OpenBSD, as currently `XPREFIX` under `.if` never gets assigned.